### PR TITLE
Feature/custom callbacks

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -18,9 +18,7 @@ train_params:
 
     # Model checkpoint callback.
     ModelCheckpoint:
-      # Only mention the model name here, a folder called 'checkpoints' containing checkpoints will be created in 'output_dir' specified above in
-      # 'train_params'
-      filepath: 'model.{epoch:02d}-{val_loss:.2f}.hdf5'
+      filepath: 'gs://vernal-buffer-285906/train_results/checkpoints/model.{epoch:02d}-{val_loss:.2f}.hdf5'
       monitor: 'val_accuracy'
       save_freq: 'epoch'
       verbose: 1

--- a/detectors/tf_gcp/trainer/callbacks.py
+++ b/detectors/tf_gcp/trainer/callbacks.py
@@ -1,0 +1,44 @@
+import importlib
+import os
+
+from typing import Dict, Union
+from tensorflow.keras.callbacks import Callback
+
+from detectors.tf_gcp.trainer.data_ops.io_ops import LocalIO, CloudIO
+
+
+class GCSCallback(Callback):
+
+    def __init__(self, cp_path: str, io_operator: Union[LocalIO, CloudIO]):
+        super(GCSCallback, self).__init__()
+        self.checkpoint_path = cp_path
+        self.io_operator = io_operator
+
+    def on_epoch_end(self, epoch, logs=None):
+        for cp_file in os.listdir('./checkpoints'):
+            src_path = os.path.join('./checkpoints', cp_file)
+            self.io_operator.write(src_path=src_path, dest_path=self.checkpoint_path, use_system_cmd=False)
+
+
+class CallBacksCreator(object):
+
+    @staticmethod
+    def get_callbacks(callbacks_config: Dict, model_type: str, io_operator: Union[LocalIO, CloudIO]):
+        callbacks = []
+        module = importlib.import_module('tensorflow.keras.callbacks')
+        cp_path = None
+        for cb in callbacks_config:
+            if cb == 'ModelCheckpoint':
+                cp_path, filename = os.path.split(callbacks_config[cb]['filepath'])
+                callbacks_config[cb]['filepath'] = os.path.join('./checkpoints',
+                                                                f"{model_type}_{filename}")
+
+            if cb == 'CSVLogger':
+                csv_path, filename = os.path.split(callbacks_config[cb]['filename'])
+                callbacks_config[cb]['filename'] = filename
+
+            obj = getattr(module, cb)
+            callbacks.append(obj(**callbacks_config[cb]))
+        gcs_callback = GCSCallback(cp_path=cp_path, io_operator=io_operator)
+        callbacks.append(gcs_callback)
+        return callbacks

--- a/detectors/tf_gcp/trainer/trainer.py
+++ b/detectors/tf_gcp/trainer/trainer.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from argparse import Namespace
 
 from detectors.common import BucketOps, SystemOps
+from detectors.tf_gcp.trainer.callbacks import CallBacksCreator
 from detectors.tf_gcp.trainer.data_ops.data_generator import DataGenerator
 from detectors.tf_gcp.trainer.data_ops.io_ops import CloudIO, LocalIO
 from detectors.tf_gcp.trainer.models.models import CNNModel, VGG19Model


### PR DESCRIPTION
1. Adding implementation to support creation of custom callbacks.
2. A developer can create a callback to do anything he desires, at multiple instances during an epoch, by inheriting Callback class from tensorflow.keras.callbacks module and overriding required functions.
3. This removes a lot of  restrictions of readily available callbacks. One of them that i faced was that ModelCheckpoint callback was not able to write checkpoints to Google Cloud Storage bucket directly. 
4. I created a separate callback to copy locally saved checkpoints by ModelCheckpoint, to GCS bucket.